### PR TITLE
excluding NA (species that do not phonologically overlap) from Z_m

### DIFF
--- a/TraitMatching/R/classCommunity.R
+++ b/TraitMatching/R/classCommunity.R
@@ -170,7 +170,7 @@ createInter = function(impData, z, log){
       if(inherits(z, "list")) Z <- as.matrix(z[[i]])
       else Z <- as.matrix(z)
 
-      Z_m <- subset(reshape2::melt(Z))
+      Z_m <- subset(reshape2::melt(Z, na.rm = TRUE))
       Z_m <- as.data.frame(Z_m)
       colnames(Z_m) <- c("X","Y")
 


### PR DESCRIPTION
I am interested in using this code to evaluate whether or not plant and pollinator species will interact (classification) based on their morphological traits. However, I want to exclude interactions between species who do not phonologically overlap from the Z matrix. Because there were three unique values of the Z matrix (1, 0, NA) the code was defaulting to regression, adding "na.rm = TRUE" to this line solves the issue.

Z_m <- subset(reshape2::melt(Z, na.rm = TRUE))